### PR TITLE
Run quality assurance tools on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -41,8 +41,24 @@ jobs:
           command: bin/console doctrine:fixtures:load --no-interaction --env=test
 
       - run:
+          name: PHPSpec
+          command: ./vendor/bin/phpspec run
+
+      - run:
           name: PHPUnit
           command: ./vendor/bin/phpunit
+
+      - run:
+          name: Behat
+          command: ./vendor/bin/behat
+
+      - run:
+          name: PHPStan
+          command: ./vendor/bin/phing phpstan
+
+      - run:
+          name: Code standards
+          command: ./vendor/bin/phing check-codestandards
 
       - save_cache:
           key: cache-v1-{{ checksum "composer.lock" }}


### PR DESCRIPTION
In order to keep good code quality
For maintainers
We need to run phpmd,phpcs,php-cs-fixer & phpstan on CircleCI


Closes #41