### PR TITLE
CircleCI: Wait for mysql to boot

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,10 @@ jobs:
           command: composer install -n --prefer-dist
 
       - run:
+          name: Wait for MySQL to show up
+          command: dockerize -wait tcp://localhost:3306 -timeout 1m
+
+      - run:
           name: Run migrations
           command: bin/console doctrine:migrations:migrate --no-interaction --env=test
 


### PR DESCRIPTION
Sometimes CircleCI runs so fast that MySQL doesnt get to boot up by the time migrations are running, we need to add wait time after composer


Closes #45