### PR TITLE
Markdown to HTML converter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "license": "proprietary",
     "require": {
         "php": "^7.1.3",
+        "erusev/parsedown": "^1.6",
         "friendsofsymfony/user-bundle": "dev-master",
         "javiereguiluz/easyadmin-bundle": "^1.17",
         "nette/utils": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "00991f999f24f957058800397838ff27",
+    "content-hash": "886896d10a5e5e898bda8ea25bcec67b",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -980,6 +980,51 @@
                 "validator"
             ],
             "time": "2017-11-15T23:40:40+00:00"
+        },
+        {
+            "name": "erusev/parsedown",
+            "version": "1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "time": "2017-11-14T20:44:03+00:00"
         },
         {
             "name": "friendsofsymfony/user-bundle",

--- a/symfony.lock
+++ b/symfony.lock
@@ -107,6 +107,9 @@
     "egulias/email-validator": {
         "version": "2.1.3"
     },
+    "erusev/parsedown": {
+        "version": "1.6.4"
+    },
     "friendsofphp/php-cs-fixer": {
         "version": "2.2",
         "recipe": {


### PR DESCRIPTION
In order to write texts in markdown and not HTML
For content creators
We need to add erusev/parsedown


Closes #86