### PR TITLE
Stop forwarding Croatian users to HR part of the site

### DIFF
--- a/src/App/Controller/HomepageController.php
+++ b/src/App/Controller/HomepageController.php
@@ -30,7 +30,7 @@ class HomepageController
      */
     public function indexAction(Request $request)
     {
-        $preferredLanguage = $request->getPreferredLanguage(['en', 'hr']);
+        $preferredLanguage = $request->getPreferredLanguage(['en']);
 
         $url = $this->router->generate('homepage', ['_locale' => $preferredLanguage]);
 

--- a/tests/App/Controller/HomepageControllerTest.php
+++ b/tests/App/Controller/HomepageControllerTest.php
@@ -34,7 +34,7 @@ class HomepageControllerTest extends WebTestCase
 
         // Assert
         self::assertTrue($client->getResponse() instanceof RedirectResponse);
-        self::assertEquals('/hr/', $location);
+        self::assertEquals('/en/', $location);
     }
 
     /**


### PR DESCRIPTION
Until we fill workshop descriptions with Croatian content, forwarding
users to HR homepage makes no sense

Closes #89